### PR TITLE
test: add unit tests for driver and API

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8.0.0
+pytest-flask>=1.3.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,82 @@
+from unittest.mock import patch
+
+import pytest
+
+
+MOCK_SENSOR = {
+    'name': 'bme280',
+    'brand': 'Waveshare',
+    'part_number': 'BME280 Environmental Sensor',
+    'sku': 15231,
+    'upc': 614961952638,
+    'chip': {'id': 96, 'version': 0},
+    'capabilities': {
+        'temperature': {'unit_of_measurement': '°C', 'min': -40, 'max': 85, 'resolution': 0.01, 'accuracy': 1},
+        'humidity': {'unit_of_measurement': '%RH', 'min': 0, 'max': 100, 'resolution': 0.008, 'accuracy': 3},
+        'pressure': {'unit_of_measurement': 'hPa', 'min': 300, 'max': 1100, 'resolution': 0.008, 'accuracy': 0.0018},
+    },
+    'data': {'temperature': 21.55, 'humidity': 44.57, 'pressure': 1005.16},
+}
+
+
+@pytest.fixture
+def client():
+    import sensor_api
+    sensor_api.app.config['TESTING'] = True
+    return sensor_api.app.test_client()
+
+
+# --- Health / index ---
+
+def test_health_returns_ok(client):
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    assert resp.json['status'] == 'ok'
+
+
+def test_index_returns_empty_json(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert resp.json == {}
+
+
+# --- /bme280 ---
+
+def test_bme280_returns_sensor_data(client):
+    with patch('sensor_api.bme280.sensor', return_value=MOCK_SENSOR):
+        resp = client.get('/bme280')
+    assert resp.status_code == 200
+    assert resp.json['name'] == 'bme280'
+    assert resp.json['data']['temperature'] == 21.55
+
+
+def test_bme280_returns_503_when_sensor_unavailable(client):
+    with patch('sensor_api.bme280.sensor', side_effect=OSError('No such file: /dev/i2c-1')):
+        resp = client.get('/bme280')
+    assert resp.status_code == 503
+    assert resp.json['error'] == 'Sensor unavailable'
+
+
+# --- /bme280/publish ---
+
+def test_publish_returns_200_with_topics(client):
+    with patch('sensor_api.bme280.sensor', return_value=MOCK_SENSOR):
+        with patch('sensor_api.mqtt_publish.multiple'):
+            resp = client.get('/bme280/publish')
+    assert resp.status_code == 200
+    assert resp.json['published'] is True
+    assert len(resp.json['topics']) == 3
+
+
+def test_publish_returns_503_when_sensor_unavailable(client):
+    with patch('sensor_api.bme280.sensor', side_effect=OSError('I2C error')):
+        resp = client.get('/bme280/publish')
+    assert resp.status_code == 503
+
+
+def test_publish_returns_502_when_mqtt_fails(client):
+    with patch('sensor_api.bme280.sensor', return_value=MOCK_SENSOR):
+        with patch('sensor_api.mqtt_publish.multiple', side_effect=Exception('Connection refused')):
+            resp = client.get('/bme280/publish')
+    assert resp.status_code == 502
+    assert resp.json['error'] == 'MQTT publish failed'

--- a/tests/test_bme280.py
+++ b/tests/test_bme280.py
@@ -1,0 +1,109 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def make_mock_bus(chip_id: int = 96, chip_version: int = 0) -> MagicMock:
+    bus = MagicMock()
+    bus.read_i2c_block_data.side_effect = [
+        [chip_id, chip_version],   # read_id
+        [0] * 24,                  # cal1 - T and P calibration
+        [0],                       # cal2 - H1
+        [0] * 7,                   # cal3 - H2-H6
+        [0] * 8,                   # raw sensor data
+    ]
+    return bus
+
+
+@pytest.fixture
+def patched_smbus():
+    mock_bus = make_mock_bus()
+    with patch('bme280.smbus2.SMBus') as MockSMBus:
+        instance = MockSMBus.return_value
+        instance.__enter__ = MagicMock(return_value=mock_bus)
+        instance.__exit__ = MagicMock(return_value=False)
+        yield mock_bus
+
+
+# --- Helper functions (pure, no hardware) ---
+
+def test_get_short_positive():
+    from bme280 import _get_short
+    assert _get_short([0x78, 0x6C], 0) == 27768  # 0x6C78
+
+
+def test_get_short_negative():
+    from bme280 import _get_short
+    assert _get_short([0x00, 0xFF], 0) == -256  # 0xFF00 as signed
+
+
+def test_get_ushort():
+    from bme280 import _get_ushort
+    assert _get_ushort([0x48, 0x67], 0) == 26440  # 0x6748
+
+
+def test_get_char_positive():
+    from bme280 import _get_char
+    assert _get_char([50], 0) == 50
+
+
+def test_get_char_negative():
+    from bme280 import _get_char
+    assert _get_char([200], 0) == -56  # 200 - 256
+
+
+def test_get_uchar():
+    from bme280 import _get_uchar
+    assert _get_uchar([0xAB], 0) == 0xAB
+
+
+# --- read_id ---
+
+def test_read_id_returns_chip_id_and_version(patched_smbus):
+    import bme280
+    chip_id, chip_version = bme280.read_id()
+    assert chip_id == 96
+    assert chip_version == 0
+
+
+def test_read_id_custom_chip_id():
+    bus = make_mock_bus(chip_id=96, chip_version=0)
+    with patch('bme280.smbus2.SMBus') as MockSMBus:
+        instance = MockSMBus.return_value
+        instance.__enter__ = MagicMock(return_value=bus)
+        instance.__exit__ = MagicMock(return_value=False)
+        import bme280
+        chip_id, _ = bme280.read_id()
+        assert chip_id == 96
+
+
+# --- sensor() structure ---
+
+def test_sensor_returns_required_keys(patched_smbus):
+    import bme280
+    result = bme280.sensor()
+    assert result['name'] == 'bme280'
+    assert 'data' in result
+    assert 'capabilities' in result
+    assert 'chip' in result
+
+
+def test_sensor_data_has_three_measurements(patched_smbus):
+    import bme280
+    data = bme280.sensor()['data']
+    assert 'temperature' in data
+    assert 'humidity' in data
+    assert 'pressure' in data
+
+
+def test_humidity_clamped_within_range(patched_smbus):
+    import bme280
+    result = bme280.sensor()
+    assert 0.0 <= result['data']['humidity'] <= 100.0
+
+
+def test_pressure_zero_when_p1_calibration_is_zero(patched_smbus):
+    # P1=0 triggers the zero-division guard in the compensation formula
+    import bme280
+    result = bme280.sensor()
+    assert result['data']['pressure'] == 0.0


### PR DESCRIPTION
## Summary

- Add `tests/test_bme280.py`: tests for pure helper functions and `sensor()` with `smbus2` fully mocked — no hardware required
- Add `tests/test_api.py`: tests for all Flask routes (`/`, `/health`, `/bme280`, `/bme280/publish`) including 503 and 502 error paths
- Add `pytest.ini` with `testpaths` and `pythonpath` config
- Add `requirements-dev.txt` pulling in `pytest` and `pytest-flask`

19 tests, 0 failures.

## Test plan

- [ ] `pip install -r requirements-dev.txt`
- [ ] `pytest tests/ -v` → 19 passed