### PR TITLE
feat: add multi-stage Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim AS base
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+
+FROM base AS test
+
+COPY requirements-dev.txt .
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+COPY . .
+
+CMD ["pytest", "tests/", "-v", "--tb=short"]
+
+
+FROM base AS app
+
+COPY bme280.py sensor_api.py ./
+
+EXPOSE 5000
+
+CMD ["python", "sensor_api.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  test:
+    build:
+      context: .
+      target: test
+
+  app:
+    build:
+      context: .
+      target: app
+    ports:
+      - "5000:5000"
+    env_file:
+      - .env
+    # Uncomment on Raspberry Pi to pass through the I2C bus
+    # devices:
+    #   - /dev/i2c-1:/dev/i2c-1


### PR DESCRIPTION
## Summary

- Add multi-stage `Dockerfile` with two targets:
  - `test`: installs dev deps, runs `pytest tests/ -v`
  - `app`: minimal image, exposes port 5000, runs `sensor_api.py`
- Add `docker-compose.yml` with:
  - `test` service: `docker compose run --rm test`
  - `app` service: ready for Raspberry Pi with I2C device passthrough (commented, uncomment on Pi)

## Test plan

- [ ] `docker build --target test -t bme280-test .` builds successfully
- [ ] `docker run --rm bme280-test` → 19 passed
- [ ] `docker build --target app -t bme280-app .` builds successfully