### PR TITLE
ci: add GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, master]
+  pull_request:
+    branches: [develop, master]
+
+jobs:
+  test:
+    name: Build & test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: test
+          load: true
+          tags: bme280-test:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run tests
+        run: docker run --rm bme280-test:ci
+
+  security:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pip-audit
+        run: pip install pip-audit --quiet
+
+      - name: Audit dependencies
+        run: pip-audit -r requirements.txt


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` with two jobs:
  - **test**: builds the `test` Docker target with GHA layer cache and runs `pytest` inside the container — no Python setup needed on the runner, hardware fully mocked
  - **security**: installs `pip-audit` and audits `requirements.txt` for known CVEs
- Triggers on push and pull_request to `develop` and `master`

## Test plan

- [ ] Open a PR to develop → both jobs appear in the checks
- [ ] `test` job passes (19 tests)
- [ ] `security` job passes with no CVEs
- [ ] Introduce a failing test → `test` job turns red