### PR TITLE
ci: add flake8 and mypy lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
     branches: [develop, master]
 
 jobs:
+  lint:
+    name: Lint & type check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install lint dependencies
+        run: pip install flake8 mypy --quiet
+
+      - name: flake8
+        run: flake8 bme280.py sensor_api.py --max-line-length=120
+
+      - name: mypy
+        run: mypy bme280.py sensor_api.py --ignore-missing-imports
+
   test:
     name: Build & test
     runs-on: ubuntu-latest

--- a/bme280.py
+++ b/bme280.py
@@ -124,7 +124,9 @@ def sensor(addr: int = DEVICE_ADDRESS) -> dict:
         'capabilities': {
             'temperature': {'unit_of_measurement': '°C', 'min': -40, 'max': 85, 'resolution': 0.01, 'accuracy': 1},
             'humidity': {'unit_of_measurement': '%RH', 'min': 0, 'max': 100, 'resolution': 0.008, 'accuracy': 3},
-            'pressure': {'unit_of_measurement': 'hPa', 'min': 300, 'max': 1100, 'resolution': 0.008, 'accuracy': 0.0018},
+            'pressure': {
+                'unit_of_measurement': 'hPa', 'min': 300, 'max': 1100, 'resolution': 0.008, 'accuracy': 0.0018,
+            },
         },
         'data': {
             'temperature': temperature,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 -r requirements.txt
 pytest>=8.0.0
 pytest-flask>=1.3.0
+flake8>=7.0.0
+mypy>=1.0.0


### PR DESCRIPTION
## Summary

- Add `lint` job to `.github/workflows/ci.yml` running:
  - `flake8 bme280.py sensor_api.py --max-line-length=120`
  - `mypy bme280.py sensor_api.py --ignore-missing-imports`
- Fix pre-existing E501 violation in `bme280.py:127` (pressure capabilities dict split across lines)
- Add `flake8>=7.0.0` and `mypy>=1.0.0` to `requirements-dev.txt`

CI pipeline now has three independent jobs:

| Job | Tool | Covers |
|-----|------|--------|
| `lint` | flake8 + mypy | Style violations, type errors |
| `test` | pytest via Docker | Business logic, API routes |
| `security` | pip-audit | CVEs in runtime deps |

## Test plan

- [ ] PR check shows three jobs: `lint`, `test`, `security`
- [ ] `lint` job passes on this branch
- [ ] Introducing a type error → `mypy` turns red
- [ ] Introducing a long line → `flake8` turns red