### PR TITLE
fix: poll measuring status register instead of fixed sleep only

### DIFF
--- a/bme280.py
+++ b/bme280.py
@@ -61,9 +61,15 @@ def read_all(addr: int = DEVICE_ADDRESS) -> tuple[float, float, float]:
         cal2 = bus.read_i2c_block_data(addr, 0xA1, 1)
         cal3 = bus.read_i2c_block_data(addr, 0xE1, 7)
 
-        # Datasheet Appendix B: measurement time formula
+        # Datasheet Appendix B: minimum wait before first status check
         wait_ms = 1.25 + (2.3 * OVERSAMPLE_TEMP) + ((2.3 * OVERSAMPLE_PRES) + 0.575) + ((2.3 * OVERSAMPLE_HUM) + 0.575)
         time.sleep(wait_ms / 1000)
+
+        # Poll measuring bit (0xF3 bit 3) until measurement is complete
+        for _ in range(20):
+            if not (bus.read_byte_data(addr, 0xF3) & 0x08):
+                break
+            time.sleep(0.001)
 
         data = bus.read_i2c_block_data(addr, 0xF7, 8)
 

--- a/tests/test_bme280.py
+++ b/tests/test_bme280.py
@@ -120,3 +120,22 @@ def test_nvm_copy_timeout_raises_oserror():
         import bme280
         with pytest.raises(OSError, match="NVM copy"):
             bme280.read_all()
+
+
+def test_read_all_polls_measuring_bit():
+    bus = MagicMock()
+    # First call: NVM done (bit 0 = 0), then measuring active (bit 3 = 1), then done (0)
+    bus.read_byte_data.side_effect = [0x00, 0x08, 0x00]
+    bus.read_i2c_block_data.side_effect = [
+        [0] * 24,
+        [0],
+        [0] * 7,
+        [0] * 8,
+    ]
+    with patch('bme280.smbus2.SMBus') as MockSMBus:
+        instance = MockSMBus.return_value
+        instance.__enter__ = MagicMock(return_value=bus)
+        instance.__exit__ = MagicMock(return_value=False)
+        import bme280
+        temperature, pressure, humidity = bme280.read_all()
+    assert bus.read_byte_data.call_count == 3


### PR DESCRIPTION
## Summary

- After the Appendix B minimum sleep, poll status register `0xF3` bit 3 (`measuring`) with up to 20 retries at 1ms intervals before reading raw data
- Eliminates rare race condition where sensor is still measuring when data registers are read
- Add `test_read_all_polls_measuring_bit`: verifies poll loop is triggered when measuring bit is active on first check

Per [Bosch BME280 SensorAPI](https://github.com/boschsensortec/BME280_SensorAPI) recommended flow.

## Test plan

- [ ] 21 tests pass: `docker compose run --rm test`