### PR TITLE
feat: add IIR filter configuration via BME280_IIR_FILTER env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # I2C configuration
 BME280_I2C_BUS=1
 BME280_I2C_ADDRESS=0x77
+# IIR filter coefficient: 0=off 1=2x 2=4x 3=8x 4=16x (recommended: 2 for indoor use)
+BME280_IIR_FILTER=0
 
 # MQTT broker
 MQTT_BROKER_HOST=192.168.1.x

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ All settings are driven by environment variables. Copy `.env.example` to `.env` 
 |----------|---------|-------------|
 | `BME280_I2C_BUS` | `1` | I²C bus number (`1` for Pi Rev 2+, `0` for Rev 1) |
 | `BME280_I2C_ADDRESS` | `0x77` | Sensor I²C address (`0x77` or `0x76` depending on SDO pin) |
+| `BME280_IIR_FILTER` | `0` | IIR filter coefficient: `0`=off, `1`=2×, `2`=4×, `3`=8×, `4`=16× (recommended: `2` for indoor use) |
 | `MQTT_BROKER_HOST` | `localhost` | IP or hostname of your MQTT broker |
 | `MQTT_USERNAME` | _(empty)_ | MQTT username (leave empty for anonymous) |
 | `MQTT_PASSWORD` | _(empty)_ | MQTT password |
@@ -123,6 +124,7 @@ All settings are driven by environment variables. Copy `.env.example` to `.env` 
 ```ini
 BME280_I2C_BUS=1
 BME280_I2C_ADDRESS=0x77
+BME280_IIR_FILTER=0
 
 MQTT_BROKER_HOST=192.168.1.10
 MQTT_USERNAME=homeassistant

--- a/bme280.py
+++ b/bme280.py
@@ -7,6 +7,9 @@ import smbus2
 I2C_BUS = int(os.environ.get('BME280_I2C_BUS', '1'))
 DEVICE_ADDRESS = int(os.environ.get('BME280_I2C_ADDRESS', '0x77'), 16)
 
+# IIR filter coefficient: 0=off, 1=2, 2=4, 3=8, 4=16 (see datasheet table 28)
+IIR_FILTER = int(os.environ.get('BME280_IIR_FILTER', '0'))
+
 
 def _get_short(data: list[int], index: int) -> int:
     return c_short((data[index + 1] << 8) + data[index]).value
@@ -54,6 +57,7 @@ def read_all(addr: int = DEVICE_ADDRESS) -> tuple[float, float, float]:
         time.sleep(0.002)  # 2ms startup delay (datasheet section 4.2)
         _wait_nvm_copy(bus, addr)
 
+        bus.write_byte_data(addr, 0xF5, IIR_FILTER << 2)  # config: filter bits [4:2]
         bus.write_byte_data(addr, 0xF2, OVERSAMPLE_HUM)
         bus.write_byte_data(addr, 0xF4, OVERSAMPLE_TEMP << 5 | OVERSAMPLE_PRES << 2 | MODE)
 


### PR DESCRIPTION
## Summary

- Write config register `0xF5` (bits [4:2]) with the IIR filter coefficient before each measurement
- New env var `BME280_IIR_FILTER`: `0`=off (default), `1`=2×, `2`=4×, `3`=8×, `4`=16×
- Default is `0` (filter off) to preserve existing behavior
- Document in `.env.example` and README configuration table

Per [Bosch BME280 datasheet table 28](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme280-ds002.pdf): IIR filter suppresses short-term disturbances (door slams, wind gusts). Recommended coefficient 4 or 8 for indoor navigation use cases.

## Test plan

- [ ] 21 tests pass: `docker compose run --rm test`
- [ ] `BME280_IIR_FILTER=2 python sensor_api.py` applies 4× filter on Pi